### PR TITLE
更新typescript版本, 使用 semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "typescript": "2.0.3"
+    "typescript": "^2.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fis3-parser-typescript",
   "description": "A parser plugin for fis3 to compile typescript(ts) file.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "FIS Team <fis@baidu.com>",
   "homepage": "http://fis.baidu.com/",
   "keywords": [


### PR DESCRIPTION
新的typescript版本又添加了新的功能. 使用特定的2.0.3的话, 新功能就没法使用

ping @2betop  